### PR TITLE
feat: add Rhinestone card account withdraw scripts and migrate to sendTx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@rhinestone/module-sdk": "^0.4.0",
-        "@rhinestone/sdk": "^1.7.0",
+        "@rhinestone/sdk": "^1.9.2",
         "@startale-scs/aa-sdk": "^1.0.14",
         "axios": "^1.11.0",
         "chalk": "^5.4.1",
@@ -21,7 +21,7 @@
         "ink": "^5.1.0",
         "ora": "^8.2.0",
         "p-limit": "^6.2.0",
-        "permissionless": "^0.2.52",
+        "permissionless": "^0.0.1",
         "solady": "^0.1.8",
         "ts-node": "^10.9.2",
         "typescript": "^5.7.3",
@@ -159,12 +159,12 @@
       "license": "MIT"
     },
     "node_modules/@rhinestone/sdk": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@rhinestone/sdk/-/sdk-1.7.0.tgz",
-      "integrity": "sha512-mLNLst294CynS1yf9p8nEUDdV2Zvg5OmJHJlA7QLd+5D8vbfg5agPEo8pJZZ9M18aPqwFyIwwG943dlhvlYIsw==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@rhinestone/sdk/-/sdk-1.9.2.tgz",
+      "integrity": "sha512-Y5jV6o24i+PhvWO6t7xWrKZ4sA+Kpbb3fVGsGVAxiW06ztV820Ad1keumARegsHe2WhXDQpuNZA4cEKEoS0jRg==",
       "license": "MIT",
       "dependencies": {
-        "@rhinestone/shared-configs": "1.6.8",
+        "@rhinestone/shared-configs": "1.6.10",
         "solady": "^0.1.26"
       },
       "peerDependencies": {
@@ -182,9 +182,9 @@
       }
     },
     "node_modules/@rhinestone/shared-configs": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/@rhinestone/shared-configs/-/shared-configs-1.6.8.tgz",
-      "integrity": "sha512-6HaQWmBiQcBgeyU0vuw1ERU/hdVlERFXEUBVIoAzbfnKvqrPwXsAhMDz6RzhRnw2Ha05LyYkM9EEV8IJnkbMVw==",
+      "version": "1.6.10",
+      "resolved": "https://registry.npmjs.org/@rhinestone/shared-configs/-/shared-configs-1.6.10.tgz",
+      "integrity": "sha512-rUSmn78bzXohGhwohuS39qCiDZlMgVrBpvoDb7ZRNi/fJ0Nb62EwtbdktCyB5ACl2vRaR2Or04TO7y+3tHBO0A==",
       "peerDependencies": {
         "typescript": "^5",
         "viem": "^2.40.1"
@@ -296,7 +296,6 @@
       "version": "25.9.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
       "integrity": "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
@@ -789,16 +788,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -1390,19 +1389,10 @@
       }
     },
     "node_modules/permissionless": {
-      "version": "0.2.57",
-      "resolved": "https://registry.npmjs.org/permissionless/-/permissionless-0.2.57.tgz",
-      "integrity": "sha512-QrzAoQGYPV/NJ2x5Sj18h7qed6f+kCyQAojrncN091UPiGqHjFNjgdsgreiv8pxlQgF4UcpuJUvsHLpOEBd6cQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "ox": "^0.8.0",
-        "viem": "^2.28.1"
-      },
-      "peerDependenciesMeta": {
-        "ox": {
-          "optional": true
-        }
-      }
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/permissionless/-/permissionless-0.0.1.tgz",
+      "integrity": "sha512-gEo7kUJ0EaXr86qXjXpu2G+wFJw5YXhysgI6RWobY0dGtGJHoaeQHVLC4XsdlRtx/K1QpNf0QMl3Pny+txeKww==",
+      "license": "MIT"
     },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
@@ -1411,6 +1401,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react-reconciler": {
@@ -1658,7 +1661,6 @@
       "version": "7.24.6",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/universalify": {
@@ -1677,9 +1679,9 @@
       "license": "MIT"
     },
     "node_modules/viem": {
-      "version": "2.52.2",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.52.2.tgz",
-      "integrity": "sha512-HSU12p5aD/kAPZfrlbCUqdiP4P/c6hQ9AhfTS51VbLUQIjkWd1d5EjrCx/SCxZ0zhZVRn4Iv5X5WDqXPG8Ubew==",
+      "version": "2.53.1",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.53.1.tgz",
+      "integrity": "sha512-FhfJ/SW73CVosiyVLmIMVgKDRKYV1AGCLzZoHYvmNayyVff63Qi1ocPCk59LqC/cNw244RbBJjHnmxqXkE7NpA==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "description": "",
   "dependencies": {
     "@rhinestone/module-sdk": "^0.4.0",
-    "@rhinestone/sdk": "^1.7.0",
+    "@rhinestone/sdk": "^1.9.2",
     "@startale-scs/aa-sdk": "^1.0.14",
     "axios": "^1.11.0",
     "chalk": "^5.4.1",
@@ -26,7 +26,7 @@
     "ink": "^5.1.0",
     "ora": "^8.2.0",
     "p-limit": "^6.2.0",
-    "permissionless": "^0.2.52",
+    "permissionless": "^0.0.1",
     "solady": "^0.1.8",
     "ts-node": "^10.9.2",
     "typescript": "^5.7.3",

--- a/src/sepolia/demo_rhinestone_startale_send_test.ts
+++ b/src/sepolia/demo_rhinestone_startale_send_test.ts
@@ -1,0 +1,76 @@
+import "dotenv/config";
+import { type Hex } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { sepolia } from "viem/chains";
+import { createRhinestoneAccount } from "@rhinestone/sdk";
+import chalk from "chalk";
+
+const privateKey = process.env.OWNER_PRIVATE_KEY;
+const rhinestoneApiKey = process.env.RHINESTONE_API_KEY;
+
+if (!privateKey || !rhinestoneApiKey) throw new Error("OWNER_PRIVATE_KEY or RHINESTONE_API_KEY not set");
+
+const K1_DEFAULT_VALIDATOR = "0x00000072f286204bb934ed49d8969e86f7dec7b1" as `0x${string}`;
+
+const chain = sepolia;
+const signer = privateKeyToAccount(privateKey as Hex);
+
+const main = async () => {
+  console.log(chalk.bold("\n=== Rhinestone sendTransaction vs sendUserOperation (K1 module) ===\n"));
+  console.log("Signer (EOA):", chalk.cyan(signer.address));
+
+  const account = await createRhinestoneAccount({
+    account: { type: "startale" as const },
+    owners: {
+      type: "ecdsa",
+      accounts: [signer],
+      module: K1_DEFAULT_VALIDATOR,
+    },
+    apiKey: rhinestoneApiKey,
+  });
+
+  const address = account.getAddress();
+  console.log("Account:", chalk.cyan(address));
+
+  const deployed = await account.isDeployed(chain);
+  console.log("Deployed:", deployed);
+  if (!deployed) {
+    console.log("\nDeploying (sponsored)...");
+    await account.deploy(chain, { sponsored: true });
+    console.log(chalk.green("Deployed ✔"));
+  }
+
+  // ── sendTransaction ──────────────────────────────────────────────────────────
+  console.log(chalk.bold("\n[1] sendTransaction (intent path, sponsored)"));
+  try {
+    const result = await account.sendTransaction({
+      chain,
+      calls: [{ to: address, value: 0n, data: "0x" }],
+      sponsored: true,
+    });
+    console.log("Intent result:", result);
+    const status = await account.waitForExecution(result);
+    console.log(chalk.greenBright("✔ sendTransaction succeeded"), status);
+  } catch (e) {
+    console.log(chalk.red("✖ sendTransaction failed:"), (e as Error).message);
+  }
+
+  // ── sendUserOperation ────────────────────────────────────────────────────────
+  console.log(chalk.bold("\n[2] sendUserOperation (ERC-4337 bundler path)"));
+  try {
+    const result = await account.sendUserOperation({
+      chain,
+      calls: [{ to: address, value: 0n, data: "0x" }],
+    });
+    console.log("UserOp hash:", result.hash);
+    const status = await account.waitForExecution(result);
+    console.log(chalk.greenBright("✔ sendUserOperation succeeded"), status);
+  } catch (e) {
+    console.log(chalk.red("✖ sendUserOperation failed:"), (e as Error).message);
+  }
+};
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/sepolia/rhinestone-card-controller/demo_nexus_deposit_from_user_account.ts
+++ b/src/sepolia/rhinestone-card-controller/demo_nexus_deposit_from_user_account.ts
@@ -1,7 +1,6 @@
 import "dotenv/config";
 import ora from "ora";
 import {
-  http,
   type Address,
   type Hex,
   encodeFunctionData,
@@ -14,14 +13,14 @@ import chalk from "chalk";
 
 const privateKey = process.env.OWNER_PRIVATE_KEY;
 const controllerValidatorAddress = process.env.CONTROLLER_VALIDATOR_ADDRESS as Address;
-const pimlicoApiKey = process.env.PIMLICO_API_KEY;
+const rhinestoneApiKey = process.env.RHINESTONE_API_KEY;
 const cardAccountAddress = process.env.NEXUS_CARD_ACCOUNT_ADDRESS as Address;
 const usdscAddress = (process.env.SEPOLIA_USDSC_ADDRESS ?? "0x7E426d026f604d1c47b50059752122d8ab1E2C28") as Address;
 const depositAmountUsdsc = process.env.DEPOSIT_AMOUNT_USDSC ?? "500";
 
-if (!privateKey || !controllerValidatorAddress || !pimlicoApiKey || !cardAccountAddress) {
+if (!privateKey || !controllerValidatorAddress || !rhinestoneApiKey || !cardAccountAddress) {
   throw new Error(
-    "OWNER_PRIVATE_KEY, CONTROLLER_VALIDATOR_ADDRESS, PIMLICO_API_KEY, or NEXUS_CARD_ACCOUNT_ADDRESS is not set"
+    "OWNER_PRIVATE_KEY, CONTROLLER_VALIDATOR_ADDRESS, RHINESTONE_API_KEY, or NEXUS_CARD_ACCOUNT_ADDRESS is not set"
   );
 }
 
@@ -56,29 +55,23 @@ const main = async () => {
 
     const account = await createRhinestoneAccount({
       account: { type: "nexus", version: "1.2.0" },
-
       owners: {
         type: "ecdsa",
         accounts: [signer],
         threshold: 1,
         module: controllerValidatorAddress,
       },
-
-      // 'pimlico' type calls pimlico_getUserOperationGasPrice for correct fee
-      // estimation. Safe to use here since the account is already deployed —
-      // deploy() inside sendUserOperation is a no-op when isDeployed = true.
-      bundler: { type: "pimlico" as const, apiKey: pimlicoApiKey },
-
-      provider: {
-        type: "custom" as const,
-        urls: { [chain.id]: chain.rpcUrls.default.http[0] },
-      },
+      apiKey: rhinestoneApiKey,
     });
 
     const nexusAddress = account.getAddress();
     spinner.succeed(`Nexus account (controller): ${chalk.cyan(nexusAddress)}`);
     console.log("EOA (signer):", signer.address);
     console.log("Card account:", cardAccountAddress);
+
+    spinner.start("Checking deployment status...");
+    await account.isDeployed(chain);
+    spinner.succeed("Deployment status checked");
 
     const amount = parseUnits(depositAmountUsdsc, 6);
     console.log(`Depositing ${depositAmountUsdsc} USDSC (${amount} units) → card account`);
@@ -89,24 +82,25 @@ const main = async () => {
       args: [{ token: usdscAddress, amount }],
     });
 
-    spinner.start("Sending depositFromUserAccount UserOp via ControllerValidator...");
+    spinner.start("Sending depositFromUserAccount via sendTransaction (sponsored)...");
 
-    const result = await account.sendUserOperation({
+    const result = await account.sendTransaction({
       chain,
       calls: [{ to: cardAccountAddress, data: callData, value: 0n }],
+      sponsored: true,
     });
 
-    console.log("\nUserOp hash:", result.hash);
+    console.log("\nIntent result:", result);
 
-    spinner.start("Waiting for receipt...");
-    const receipt = await account.waitForExecution(result);
-    console.log("Tx hash:", receipt.receipt.transactionHash);
+    spinner.start("Waiting for execution...");
+    const status = await account.waitForExecution(result);
 
     spinner.succeed(
       chalk.greenBright.bold(
         `Deposited ${depositAmountUsdsc} USDSC from user account into card account`
       )
     );
+    console.log("Status:", status);
   } catch (error) {
     spinner.fail(chalk.red(`Error: ${(error as Error).message}`));
   }

--- a/src/sepolia/rhinestone-card-controller/demo_nexus_settle_card_balance.ts
+++ b/src/sepolia/rhinestone-card-controller/demo_nexus_settle_card_balance.ts
@@ -1,7 +1,6 @@
 import "dotenv/config";
 import ora from "ora";
 import {
-  http,
   type Address,
   type Hex,
   encodeFunctionData,
@@ -16,16 +15,16 @@ import chalk from "chalk";
 
 const privateKey = process.env.OWNER_PRIVATE_KEY;
 const controllerValidatorAddress = process.env.CONTROLLER_VALIDATOR_ADDRESS as Address;
-const pimlicoApiKey = process.env.PIMLICO_API_KEY;
+const rhinestoneApiKey = process.env.RHINESTONE_API_KEY;
 const cardAccountAddress = process.env.NEXUS_CARD_ACCOUNT_ADDRESS as Address;
 const settleRecipient = (process.env.SETTLE_RECIPIENT ?? "0x22C9Baf7A0db2190AD74fCE24faBD68Ec6F97DAc") as Address;
 const usdscAddress = (process.env.SEPOLIA_USDSC_ADDRESS ?? "0x7E426d026f604d1c47b50059752122d8ab1E2C28") as Address;
 const settleAmountUsdsc = process.env.SETTLE_AMOUNT_USDSC ?? "10";
 const settlementUid = process.env.SETTLEMENT_UID as Hex | undefined;
 
-if (!privateKey || !controllerValidatorAddress || !pimlicoApiKey || !cardAccountAddress) {
+if (!privateKey || !controllerValidatorAddress || !rhinestoneApiKey || !cardAccountAddress) {
   throw new Error(
-    "OWNER_PRIVATE_KEY, CONTROLLER_VALIDATOR_ADDRESS, PIMLICO_API_KEY, or NEXUS_CARD_ACCOUNT_ADDRESS is not set"
+    "OWNER_PRIVATE_KEY, CONTROLLER_VALIDATOR_ADDRESS, RHINESTONE_API_KEY, or NEXUS_CARD_ACCOUNT_ADDRESS is not set"
   );
 }
 
@@ -62,20 +61,13 @@ const main = async () => {
 
     const account = await createRhinestoneAccount({
       account: { type: "nexus", version: "1.2.0" },
-
       owners: {
         type: "ecdsa",
         accounts: [signer],
         threshold: 1,
         module: controllerValidatorAddress,
       },
-
-      bundler: { type: "pimlico" as const, apiKey: pimlicoApiKey },
-
-      provider: {
-        type: "custom" as const,
-        urls: { [chain.id]: chain.rpcUrls.default.http[0] },
-      },
+      apiKey: rhinestoneApiKey,
     });
 
     const nexusAddress = account.getAddress();
@@ -83,6 +75,10 @@ const main = async () => {
     console.log("EOA (signer):", signer.address);
     console.log("Card account:", cardAccountAddress);
     console.log("Recipient:", settleRecipient);
+
+    spinner.start("Checking deployment status...");
+    await account.isDeployed(chain);
+    spinner.succeed("Deployment status checked");
 
     const amount = parseUnits(settleAmountUsdsc, 6);
 
@@ -104,24 +100,25 @@ const main = async () => {
       args: [settleRecipient, { token: usdscAddress, amount }, uid],
     });
 
-    spinner.start("Sending settleCardBalance UserOp via ControllerValidator...");
+    spinner.start("Sending settleCardBalance via sendTransaction (sponsored)...");
 
-    const result = await account.sendUserOperation({
+    const result = await account.sendTransaction({
       chain,
       calls: [{ to: cardAccountAddress, data: callData, value: 0n }],
+      sponsored: true,
     });
 
-    console.log("\nUserOp hash:", result.hash);
+    console.log("\nIntent result:", result);
 
-    spinner.start("Waiting for receipt...");
-    const receipt = await account.waitForExecution(result);
-    console.log("Tx hash:", receipt.receipt.transactionHash);
+    spinner.start("Waiting for execution...");
+    const status = await account.waitForExecution(result);
 
     spinner.succeed(
       chalk.greenBright.bold(
         `Settled ${settleAmountUsdsc} USDSC to ${settleRecipient}`
       )
     );
+    console.log("Status:", status);
   } catch (error) {
     spinner.fail(chalk.red(`Error: ${(error as Error).message}`));
   }

--- a/src/sepolia/rhinestone-card-controller/demo_rhinestone_fresh_account_activate.ts
+++ b/src/sepolia/rhinestone-card-controller/demo_rhinestone_fresh_account_activate.ts
@@ -1,0 +1,193 @@
+import "dotenv/config";
+import ora from "ora";
+import {
+  http,
+  type Address,
+  type Hex,
+  createPublicClient,
+  encodeFunctionData,
+  keccak256,
+  toHex,
+  maxUint256,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { sepolia } from "viem/chains";
+import { createRhinestoneAccount } from "@rhinestone/sdk";
+import chalk from "chalk";
+
+
+const K1_DEFAULT_VALIDATOR = "0x00000072f286204bb934ed49d8969e86f7dec7b1" as `0x${string}`;
+
+const privateKey = process.env.OWNER_PRIVATE_KEY;
+const bundlerUrl = process.env.SEPOLIA_BUNDLER_URL;
+const cardAccountFactoryAddress = process.env.CARD_ACCOUNT_FACTORY_ADDRESS as Address;
+const usdscAddress = (process.env.SEPOLIA_USDSC_ADDRESS ?? "0x7E426d026f604d1c47b50059752122d8ab1E2C28") as Address;
+const rhinestoneApiKey = process.env.RHINESTONE_API_KEY;
+
+if (!privateKey || !bundlerUrl || !cardAccountFactoryAddress || !rhinestoneApiKey) {
+  throw new Error(
+    "OWNER_PRIVATE_KEY, SEPOLIA_BUNDLER_URL, CARD_ACCOUNT_FACTORY_ADDRESS, or RHINESTONE_API_KEY is not set"
+  );
+}
+
+const CARD_ACCOUNT_FACTORY_ABI = [
+  {
+    name: "makeNewCardAccount",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "userAccount", type: "address" },
+      { name: "salt", type: "bytes32" },
+    ],
+    outputs: [{ name: "clone", type: "address" }],
+  },
+] as const;
+
+const ERC20_ABI = [
+  {
+    name: "approve",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "spender", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+  {
+    name: "allowance",
+    type: "function",
+    stateMutability: "view",
+    inputs: [
+      { name: "owner", type: "address" },
+      { name: "spender", type: "address" },
+    ],
+    outputs: [{ name: "", type: "uint256" }],
+  },
+] as const;
+
+const chain = sepolia;
+const publicClient = createPublicClient({ transport: http(bundlerUrl), chain });
+const signer = privateKeyToAccount(privateKey as Hex);
+
+const main = async () => {
+  const spinner = ora({ spinner: "bouncingBar" });
+
+  try {
+    spinner.start("Initializing Rhinestone Nexus account (type: startale, K1 validator)...");
+
+    const account = await createRhinestoneAccount({
+      account: { type: "startale" as const },
+      owners: {
+        type: "ecdsa",
+        accounts: [signer],
+        module: K1_DEFAULT_VALIDATOR,
+      },
+      apiKey: rhinestoneApiKey
+    });
+
+    const userAccount = account.getAddress() as Address;
+    spinner.succeed(`Nexus account: ${chalk.cyan(userAccount)}`);
+    console.log("EOA (signer):", signer.address);
+    console.log("CardAccountFactory:", cardAccountFactoryAddress);
+    console.log("USDSC:", usdscAddress);
+
+    const salt = keccak256(toHex(userAccount)) as Hex;
+
+    spinner.start("Predicting card account address...");
+    const { result: cardAccountAddress } = await publicClient.simulateContract({
+      address: cardAccountFactoryAddress,
+      abi: CARD_ACCOUNT_FACTORY_ABI,
+      functionName: "makeNewCardAccount",
+      args: [userAccount, salt as `0x${string}`],
+      account: userAccount,
+    });
+    spinner.succeed(`Card account (counterfactual): ${chalk.cyan(cardAccountAddress)}`);
+
+    // Idempotency — skip steps already done
+    const [code, currentAllowance] = await Promise.all([
+      publicClient.getCode({ address: cardAccountAddress }),
+      publicClient.readContract({
+        address: usdscAddress,
+        abi: ERC20_ABI,
+        functionName: "allowance",
+        args: [userAccount, cardAccountAddress],
+      }),
+    ]);
+
+    const isDeployed = !!code && code !== "0x";
+    const isApproved = currentAllowance === maxUint256;
+
+    console.log("Card account deployed:", isDeployed);
+    console.log("USDSC approved:", isApproved);
+
+    if (isDeployed && isApproved) {
+      spinner.succeed(chalk.greenBright.bold("Card account already activated — nothing to do"));
+      console.log(`\nSet NEXUS_CARD_ACCOUNT_ADDRESS=${cardAccountAddress} in .env`);
+      process.exit(0);
+    }
+
+    // Rhinestone's intent orchestrator simulates against on-chain state — the Nexus
+    // account must be deployed before sendTransaction, otherwise simulation reverts.
+    const nexusDeployed = await account.isDeployed(chain);
+    if (!nexusDeployed) {
+      spinner.start("Deploying Nexus account (sponsored)...");
+      await account.deploy(chain, { sponsored: true });
+      spinner.succeed(`Nexus account deployed: ${chalk.cyan(userAccount)}`);
+    }
+
+    const calls: { to: Address; value: bigint; data: Hex }[] = [];
+
+    if (!isDeployed) {
+      calls.push({
+        to: cardAccountFactoryAddress,
+        value: 0n,
+        data: encodeFunctionData({
+          abi: CARD_ACCOUNT_FACTORY_ABI,
+          functionName: "makeNewCardAccount",
+          args: [userAccount, salt as `0x${string}`],
+        }),
+      });
+    }
+
+    if (!isApproved) {
+      calls.push({
+        to: usdscAddress,
+        value: 0n,
+        data: encodeFunctionData({
+          abi: ERC20_ABI,
+          functionName: "approve",
+          args: [cardAccountAddress, maxUint256],
+        }),
+      });
+    }
+
+    const label =
+      !isDeployed && !isApproved
+        ? "makeNewCardAccount + USDSC.approve"
+        : !isDeployed
+        ? "makeNewCardAccount"
+        : "USDSC.approve";
+
+    spinner.start(`Sending sponsored transaction [${label}]...`);
+
+    const result = await account.sendTransaction({
+      chain,
+      calls,
+      sponsored: true,
+    });
+
+    console.log("\nIntent result:", result);
+    spinner.start("Waiting for execution...");
+
+    const status = await account.waitForExecution(result);
+    spinner.succeed(chalk.greenBright.bold(`Card account activated: ${cardAccountAddress}`));
+    console.log("Status:", status);
+    console.log(`\nSet NEXUS_CARD_ACCOUNT_ADDRESS=${cardAccountAddress} in .env`);
+  } catch (error) {
+    spinner.fail(chalk.red(`Error: ${(error as Error).message}`));
+  }
+  process.exit(0);
+};
+
+main();

--- a/src/sepolia/rhinestone-card-controller/demo_rhinestone_fresh_account_withdraw.ts
+++ b/src/sepolia/rhinestone-card-controller/demo_rhinestone_fresh_account_withdraw.ts
@@ -1,0 +1,198 @@
+import "dotenv/config";
+import ora from "ora";
+import {
+  type Address,
+  type Hex,
+  encodeFunctionData,
+  encodePacked,
+  parseUnits,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { sepolia } from "viem/chains";
+import { createRhinestoneAccount } from "@rhinestone/sdk";
+import chalk from "chalk";
+
+const K1_DEFAULT_VALIDATOR = "0x00000072f286204bb934ed49d8969e86f7dec7b1" as Address;
+
+const privateKey = process.env.OWNER_PRIVATE_KEY;
+const controllerValidatorAddress = process.env.CONTROLLER_VALIDATOR_ADDRESS as Address;
+const cardAccountAddress = process.env.NEXUS_CARD_ACCOUNT_ADDRESS as Address;
+const usdscAddress = (process.env.SEPOLIA_USDSC_ADDRESS ?? "0x7E426d026f604d1c47b50059752122d8ab1E2C28") as Address;
+const withdrawAmountUsdsc = process.env.WITHDRAW_AMOUNT_USDSC ?? "100";
+const rhinestoneApiKey = process.env.RHINESTONE_API_KEY;
+
+if (!privateKey || !controllerValidatorAddress || !cardAccountAddress || !rhinestoneApiKey) {
+  throw new Error(
+    "OWNER_PRIVATE_KEY, CONTROLLER_VALIDATOR_ADDRESS, NEXUS_CARD_ACCOUNT_ADDRESS, or RHINESTONE_API_KEY is not set"
+  );
+}
+
+const TRANSFER_RECIPIENT = "0x2cf491602ad22944D9047282aBC00D3e52F56B37" as Address;
+
+const ERC20_ABI = [
+  {
+    name: "transfer",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+] as const;
+
+const CARD_ACCOUNT_ABI = [
+  {
+    name: "withdrawToUserAccount",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [
+      {
+        name: "tokenAmount",
+        type: "tuple",
+        components: [
+          { name: "token", type: "address" },
+          { name: "amount", type: "uint256" },
+        ],
+      },
+      {
+        name: "authorization",
+        type: "tuple",
+        components: [
+          { name: "controllerSig", type: "bytes" },
+          { name: "nonce", type: "uint256" },
+          { name: "expiration", type: "uint48" },
+        ],
+      },
+    ],
+    outputs: [],
+  },
+] as const;
+
+const chain = sepolia;
+const signer = privateKeyToAccount(privateKey as Hex);
+
+const main = async () => {
+  const spinner = ora({ spinner: "bouncingBar" });
+
+  try {
+    spinner.start("Initializing Rhinestone Nexus account (type: startale, K1 validator)...");
+
+    const account = await createRhinestoneAccount({
+      account: { type: "startale" as const },
+      owners: {
+        type: "ecdsa",
+        accounts: [signer],
+        module: K1_DEFAULT_VALIDATOR,
+      },
+      apiKey: rhinestoneApiKey,
+    });
+
+    const userAccount = account.getAddress() as Address;
+    spinner.succeed(`Nexus account (user): ${chalk.cyan(userAccount)}`);
+    console.log("EOA (signer / controller):", signer.address);
+    console.log("Card account:", cardAccountAddress);
+
+    // Rhinestone intent orchestrator requires on-chain state — warm-up
+    spinner.start("Checking deployment status...");
+    const nexusDeployed = await account.isDeployed(chain);
+    spinner.succeed(`Deployed: ${nexusDeployed}`);
+
+    if (!nexusDeployed) {
+      throw new Error(
+        `User account ${userAccount} is not deployed. Run demo_rhinestone_fresh_account_activate.ts first.`
+      );
+    }
+
+    const amount = parseUnits(withdrawAmountUsdsc, 6);
+
+    // Non-sequential nonce — the card account tracks used nonces to prevent replay
+    const nonce = BigInt(process.env.WITHDRAW_NONCE ?? "1234567");
+    const expiration = Math.floor(Date.now() / 1000) + 3600;
+
+    console.log(`\nWithdraw ${withdrawAmountUsdsc} USDSC → user account ${userAccount}`);
+    console.log(`Nonce: ${nonce}, Expiration: ${expiration}`);
+
+    // EIP-712 controller authorization
+    // Domain confirmed via eip712Domain() on-chain: name="CardAccount", version="1"
+    spinner.start("Signing EIP-712 WithdrawRequest as controller...");
+
+    const ecdsaSig = await signer.signTypedData({
+      domain: {
+        name: "CardAccount",
+        version: "1",
+        chainId: chain.id,
+        verifyingContract: cardAccountAddress,
+      },
+      types: {
+        Withdraw: [
+          { name: "userAccount", type: "address" },
+          { name: "token", type: "address" },
+          { name: "amount", type: "uint256" },
+          { name: "nonce", type: "uint256" },
+          { name: "expires", type: "uint48" },
+        ],
+      },
+      primaryType: "Withdraw",
+      message: {
+        userAccount,
+        token: usdscAddress,
+        amount,
+        nonce,
+        expires: expiration,
+      },
+    });
+
+    // Nexus EIP-1271: prefix ECDSA sig with the validator module address so the
+    // controller Nexus account routes verification to the correct ECDSA validator.
+    const controllerSig = encodePacked(
+      ["address", "bytes"],
+      [controllerValidatorAddress, ecdsaSig]
+    );
+    spinner.succeed(`Controller signature (prefixed): ${chalk.cyan(controllerSig.slice(0, 22))}...`);
+
+    const callData = encodeFunctionData({
+      abi: CARD_ACCOUNT_ABI,
+      functionName: "withdrawToUserAccount",
+      args: [
+        { token: usdscAddress, amount },
+        { controllerSig, nonce, expiration },
+      ],
+    });
+
+    const transferCallData = encodeFunctionData({
+      abi: ERC20_ABI,
+      functionName: "transfer",
+      args: [TRANSFER_RECIPIENT, amount],
+    });
+
+    console.log(`Forward ${withdrawAmountUsdsc} USDSC → ${TRANSFER_RECIPIENT}`);
+    spinner.start(`Sending withdraw + transfer via sendTransaction (sponsored)...`);
+
+    const result = await account.sendTransaction({
+      chain,
+      calls: [
+        { to: cardAccountAddress, value: 0n, data: callData },
+        { to: usdscAddress, value: 0n, data: transferCallData },
+      ],
+      sponsored: true,
+    });
+
+    console.log("\nIntent result:", result);
+    spinner.start("Waiting for execution...");
+
+    const status = await account.waitForExecution(result);
+    spinner.succeed(
+      chalk.greenBright.bold(
+        `Withdrew ${withdrawAmountUsdsc} USDSC and forwarded to ${TRANSFER_RECIPIENT}`
+      )
+    );
+    console.log("Status:", status);
+  } catch (error) {
+    spinner.fail(chalk.red(`Error: ${(error as Error).message}`));
+  }
+  process.exit(0);
+};
+
+main();

--- a/src/sepolia/rhinestone-card-controller/demo_rhinestone_fresh_account_withdraw_userop.ts
+++ b/src/sepolia/rhinestone-card-controller/demo_rhinestone_fresh_account_withdraw_userop.ts
@@ -1,0 +1,197 @@
+import "dotenv/config";
+import ora from "ora";
+import {
+  type Address,
+  type Hex,
+  encodeFunctionData,
+  encodePacked,
+  parseUnits,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { sepolia } from "viem/chains";
+import { createRhinestoneAccount } from "@rhinestone/sdk";
+import chalk from "chalk";
+
+const K1_DEFAULT_VALIDATOR = "0x00000072f286204bb934ed49d8969e86f7dec7b1" as Address;
+
+const privateKey = process.env.OWNER_PRIVATE_KEY;
+const controllerValidatorAddress = process.env.CONTROLLER_VALIDATOR_ADDRESS as Address;
+const cardAccountAddress = process.env.NEXUS_CARD_ACCOUNT_ADDRESS as Address;
+const usdscAddress = (process.env.SEPOLIA_USDSC_ADDRESS ?? "0x7E426d026f604d1c47b50059752122d8ab1E2C28") as Address;
+const withdrawAmountUsdsc = process.env.WITHDRAW_AMOUNT_USDSC ?? "100";
+const rhinestoneApiKey = process.env.RHINESTONE_API_KEY;
+
+if (!privateKey || !controllerValidatorAddress || !cardAccountAddress || !rhinestoneApiKey) {
+  throw new Error(
+    "OWNER_PRIVATE_KEY, CONTROLLER_VALIDATOR_ADDRESS, NEXUS_CARD_ACCOUNT_ADDRESS, or RHINESTONE_API_KEY is not set"
+  );
+}
+
+const TRANSFER_RECIPIENT = "0x2cf491602ad22944D9047282aBC00D3e52F56B37" as Address;
+
+const ERC20_ABI = [
+  {
+    name: "transfer",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [
+      { name: "to", type: "address" },
+      { name: "amount", type: "uint256" },
+    ],
+    outputs: [{ name: "", type: "bool" }],
+  },
+] as const;
+
+const CARD_ACCOUNT_ABI = [
+  {
+    name: "withdrawToUserAccount",
+    type: "function",
+    stateMutability: "nonpayable",
+    inputs: [
+      {
+        name: "tokenAmount",
+        type: "tuple",
+        components: [
+          { name: "token", type: "address" },
+          { name: "amount", type: "uint256" },
+        ],
+      },
+      {
+        name: "authorization",
+        type: "tuple",
+        components: [
+          { name: "controllerSig", type: "bytes" },
+          { name: "nonce", type: "uint256" },
+          { name: "expiration", type: "uint48" },
+        ],
+      },
+    ],
+    outputs: [],
+  },
+] as const;
+
+const chain = sepolia;
+const signer = privateKeyToAccount(privateKey as Hex);
+
+const main = async () => {
+  const spinner = ora({ spinner: "bouncingBar" });
+
+  try {
+    spinner.start("Initializing Rhinestone Nexus account (type: startale, K1 validator)...");
+
+    const account = await createRhinestoneAccount({
+      account: { type: "startale" as const },
+      owners: {
+        type: "ecdsa",
+        accounts: [signer],
+        module: K1_DEFAULT_VALIDATOR,
+      },
+      apiKey: rhinestoneApiKey,
+    });
+
+    const userAccount = account.getAddress() as Address;
+    spinner.succeed(`Nexus account (user): ${chalk.cyan(userAccount)}`);
+    console.log("EOA (signer / controller):", signer.address);
+    console.log("Card account:", cardAccountAddress);
+
+    // Rhinestone intent orchestrator requires on-chain state — warm-up
+    spinner.start("Checking deployment status...");
+    const nexusDeployed = await account.isDeployed(chain);
+    spinner.succeed(`Deployed: ${nexusDeployed}`);
+
+    if (!nexusDeployed) {
+      throw new Error(
+        `User account ${userAccount} is not deployed. Run demo_rhinestone_fresh_account_activate.ts first.`
+      );
+    }
+
+    const amount = parseUnits(withdrawAmountUsdsc, 6);
+
+    // Non-sequential nonce — the card account tracks used nonces to prevent replay
+    const nonce = BigInt(process.env.WITHDRAW_NONCE ?? "12345678");
+    const expiration = Math.floor(Date.now() / 1000) + 3600;
+
+    console.log(`\nWithdraw ${withdrawAmountUsdsc} USDSC → user account ${userAccount}`);
+    console.log(`Nonce: ${nonce}, Expiration: ${expiration}`);
+
+    // EIP-712 controller authorization
+    // Domain confirmed via eip712Domain() on-chain: name="CardAccount", version="1"
+    spinner.start("Signing EIP-712 WithdrawRequest as controller...");
+
+    const ecdsaSig = await signer.signTypedData({
+      domain: {
+        name: "CardAccount",
+        version: "1",
+        chainId: chain.id,
+        verifyingContract: cardAccountAddress,
+      },
+      types: {
+        Withdraw: [
+          { name: "userAccount", type: "address" },
+          { name: "token", type: "address" },
+          { name: "amount", type: "uint256" },
+          { name: "nonce", type: "uint256" },
+          { name: "expires", type: "uint48" },
+        ],
+      },
+      primaryType: "Withdraw",
+      message: {
+        userAccount,
+        token: usdscAddress,
+        amount,
+        nonce,
+        expires: expiration,
+      },
+    });
+
+    // Nexus EIP-1271: prefix ECDSA sig with the validator module address so the
+    // controller Nexus account routes verification to the correct ECDSA validator.
+    const controllerSig = encodePacked(
+      ["address", "bytes"],
+      [controllerValidatorAddress, ecdsaSig]
+    );
+    spinner.succeed(`Controller signature (prefixed): ${chalk.cyan(controllerSig.slice(0, 22))}...`);
+
+    const callData = encodeFunctionData({
+      abi: CARD_ACCOUNT_ABI,
+      functionName: "withdrawToUserAccount",
+      args: [
+        { token: usdscAddress, amount },
+        { controllerSig, nonce, expiration },
+      ],
+    });
+
+    const transferCallData = encodeFunctionData({
+      abi: ERC20_ABI,
+      functionName: "transfer",
+      args: [TRANSFER_RECIPIENT, amount],
+    });
+
+    console.log(`Forward ${withdrawAmountUsdsc} USDSC → ${TRANSFER_RECIPIENT}`);
+    spinner.start(`Sending withdraw + transfer via sendUserOperation...`);
+
+    const result = await account.sendUserOperation({
+      chain,
+      calls: [
+        { to: cardAccountAddress, value: 0n, data: callData },
+        { to: usdscAddress, value: 0n, data: transferCallData },
+      ],
+    });
+
+    console.log("\nUserOp hash:", result.hash);
+    spinner.start("Waiting for execution...");
+
+    const status = await account.waitForExecution(result);
+    spinner.succeed(
+      chalk.greenBright.bold(
+        `Withdrew ${withdrawAmountUsdsc} USDSC and forwarded to ${TRANSFER_RECIPIENT}`
+      )
+    );
+    console.log("Status:", status);
+  } catch (error) {
+    spinner.fail(chalk.red(`Error: ${(error as Error).message}`));
+  }
+  process.exit(0);
+};
+
+main();

--- a/src/sepolia/rhinestone-card-controller/demo_rhinestone_noop_sendtransaction.ts
+++ b/src/sepolia/rhinestone-card-controller/demo_rhinestone_noop_sendtransaction.ts
@@ -1,0 +1,63 @@
+import "dotenv/config";
+import ora from "ora";
+import { type Hex } from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { sepolia } from "viem/chains";
+import { createRhinestoneAccount } from "@rhinestone/sdk";
+import chalk from "chalk";
+
+const K1_DEFAULT_VALIDATOR = "0x00000072f286204bb934ed49d8969e86f7dec7b1" as `0x${string}`;
+
+const privateKey = process.env.OWNER_PRIVATE_KEY;
+const rhinestoneApiKey = process.env.RHINESTONE_API_KEY;
+
+if (!privateKey || !rhinestoneApiKey) {
+  throw new Error("OWNER_PRIVATE_KEY or RHINESTONE_API_KEY is not set");
+}
+
+const signer = privateKeyToAccount(privateKey as Hex);
+
+const main = async () => {
+  const spinner = ora({ spinner: "bouncingBar" });
+
+  try {
+    spinner.start("Initializing Rhinestone account (type:startale + K1 validator)...");
+
+    const account = await createRhinestoneAccount({
+      account: { type: "startale" as const },
+      owners: {
+        type: "ecdsa",
+        accounts: [signer],
+        module: K1_DEFAULT_VALIDATOR,
+      },
+      apiKey: rhinestoneApiKey,
+    });
+
+    const address = account.getAddress();
+    spinner.succeed(`Account: ${chalk.cyan(address)}`);
+
+    spinner.start("Checking deployment status...");
+    const deployed = await account.isDeployed(sepolia);
+    spinner.succeed(`Deployed: ${deployed}`);
+
+    spinner.start("Sending no-op via sendTransaction (sponsored)...");
+
+    const result = await account.sendTransaction({
+      chain: sepolia,
+      calls: [{ to: address, value: 0n, data: "0x" }],
+      sponsored: true,
+    });
+
+    console.log("\nIntent result:", result);
+    spinner.start("Waiting for execution...");
+
+    const status = await account.waitForExecution(result);
+    spinner.succeed(chalk.greenBright.bold("sendTransaction no-op succeeded"));
+    console.log("Status:", status);
+  } catch (error) {
+    spinner.fail(chalk.red(`Error: ${(error as Error).message}`));
+  }
+  process.exit(0);
+};
+
+main();


### PR DESCRIPTION
- Add demo_rhinestone_fresh_account_activate: deploy Startale Nexus account, makeNewCardAccount, USDSC approve
- Add demo_rhinestone_fresh_account_withdraw: EIP-712 signed withdrawToUserAccount + forward transfer via sendTransaction (sponsored)
- Add demo_rhinestone_fresh_account_withdraw_userop: same flow via sendUserOperation
- Add demo_rhinestone_noop_sendtransaction: minimal sendTransaction no-op test with K1 validator
- Add demo_rhinestone_startale_send_test: compare sendTransaction vs sendUserOperation paths
- Migrate demo_nexus_deposit_from_user_account and demo_nexus_settle_card_balance from sendUserOperation/Pimlico to sendTransaction/Rhinestone sponsored